### PR TITLE
Initialization + simple Python wrapper

### DIFF
--- a/fast_tsne.R
+++ b/fast_tsne.R
@@ -10,6 +10,7 @@ fftRtsne <- function(X,
 		     start_late_exag_iter=-1.0,late_exag_coeff=1.0,
 		     n_trees=50, search_k = -1,rand_seed=-1,
 		     nterms=3, intervals_per_integer=1, min_num_intervals=50, 
+		     K=-1, sigma=-30, initialization=NULL,
 		     data_path=NULL, result_path=NULL,
 		     fast_tsne_path='bin/fast_tsne', nthreads=0, ...) {
 	if (is.null(data_path)) {
@@ -35,7 +36,7 @@ fftRtsne <- function(X,
 	if (!is.wholenumber(stop_lying_iter) || stop_lying_iter<0) { stop("stop_lying_iter should be a positive integer")}
 	if (!is.numeric(exaggeration_factor)) { stop("exaggeration_factor should be numeric")}
 	if (!is.wholenumber(dims) || dims<=0) { stop("Incorrect dimensionality.")}
-	if (search_k == -1) { search_k = n_trees*perplexity*3 }
+	if (search_k == -1) { if (perplexity>0) {search_k = n_trees*perplexity*3} else { search_k = n_trees*K*3} }
 
 	if (fft_not_bh){
 	  nbody_algo = 2;
@@ -60,8 +61,8 @@ fftRtsne <- function(X,
 	writeBin( as.integer(dims), f,size=4) #theta
 	writeBin( as.integer(max_iter),f,size=4)
 	writeBin( as.integer(stop_lying_iter),f,size=4)
-	writeBin( as.integer(-1),f,size=4) #K
-	writeBin( as.numeric(-30.0), f,size=8) #sigma
+	writeBin( as.integer(K),f,size=4) #K
+	writeBin( as.numeric(sigma), f,size=8) #sigma
 	writeBin( as.integer(nbody_algo), f,size=4)  #not barnes hut
 	writeBin( as.integer(knn_algo), f,size=4) 
 	writeBin( as.numeric(exaggeration_factor), f,size=8) #compexag
@@ -77,6 +78,7 @@ fftRtsne <- function(X,
 	tX = c(t(X))
 	writeBin( tX, f) 
 	writeBin( as.integer(rand_seed), f,size=4) 
+	if (! is.null(initialization)){ writeBin( c(t(initialization)), f) }		
 	close(f) 
 
 	flag= system2(command=fast_tsne_path, args=c(data_path, result_path, nthreads));

--- a/fast_tsne.py
+++ b/fast_tsne.py
@@ -19,7 +19,10 @@ def fast_tsne(X, theta=.5, perplexity=30, map_dims=2, max_iter=1000,
               seed=-1, initialization=None):
     
     if search_k is None:
-        search_k = 3 * perplexity * n_trees
+        if perplexity > 0:
+            search_k = 3 * perplexity * n_trees
+        else:
+            search_k = 3 * K * n_trees
         
     if nbody_algo == 'Barnes-Hut':
         nbody_algo = 1

--- a/fast_tsne.py
+++ b/fast_tsne.py
@@ -5,6 +5,11 @@ import numpy as np
 
 # This is really basic function that does not do any sanity checks
 # It assumes that fast_tsne.py and fast_tsne binary are both in the working directory
+#
+# Usage example:
+#	from fast_tsne import fast_tsne
+#	X = np.random.randn(1000, 50)
+#	fast_tsne(X, perplexity = 30)
 
 def fast_tsne(X, theta=.5, perplexity=30, map_dims=2, max_iter=1000, 
               stop_lying_iter=200, K=-1, sigma=-30, nbody_algo='FFT', knn_algo='annoy',

--- a/fast_tsne.py
+++ b/fast_tsne.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import struct
+import numpy as np
+
+# This is really basic function that does not do any sanity checks
+# It assumes that fast_tsne.py and fast_tsne binary are both in the working directory
+
+def fast_tsne(X, theta=.5, perplexity=30, map_dims=2, max_iter=1000, 
+              stop_lying_iter=200, K=-1, sigma=-30, nbody_algo='FFT', knn_algo='annoy',
+              early_exag_coeff=12, no_momentum_during_exag=0, n_trees=50, 
+              search_k=None, start_late_exag_iter=-1, late_exag_coeff=-1,
+              nterms=3, intervals_per_integer=1, min_num_intervals=50,            
+              seed=-1, initialization=None):
+    
+    if search_k is None:
+        search_k = 3 * perplexity * n_trees
+        
+    if nbody_algo == 'Barnes-Hut':
+        nbody_algo = 1
+    else:
+        nbody_algo = 2
+        
+    if knn_algo == 'vp-tree':
+        knn_algo = 2
+    else:
+        knn_algo = 1
+    
+    # create temp directory if it does not exist
+    if not os.path.isdir(os.getcwd()+'/temp'):
+        os.mkdir(os.getcwd()+'/temp')
+    
+    # write data file
+    with open(os.getcwd()+'/temp/data.dat', 'wb') as f:
+        n, d = X.shape
+        f.write(struct.pack('=i', n))   
+        f.write(struct.pack('=i', d))   
+        f.write(struct.pack('=d', theta))
+        f.write(struct.pack('=d', perplexity))
+        f.write(struct.pack('=i', map_dims))
+        f.write(struct.pack('=i', max_iter))
+        f.write(struct.pack('=i', stop_lying_iter))
+        f.write(struct.pack('=i', K))
+        f.write(struct.pack('=d', sigma))
+        f.write(struct.pack('=i', nbody_algo))
+        f.write(struct.pack('=i', knn_algo))
+        f.write(struct.pack('=d', early_exag_coeff))
+        f.write(struct.pack('=i', no_momentum_during_exag))
+        f.write(struct.pack('=i', n_trees))
+        f.write(struct.pack('=i', search_k))
+        f.write(struct.pack('=i', start_late_exag_iter))
+        f.write(struct.pack('=d', late_exag_coeff))
+        f.write(struct.pack('=i', nterms))
+        f.write(struct.pack('=d', intervals_per_integer))
+        f.write(struct.pack('=i', min_num_intervals))
+        f.write(X.tobytes()) 
+        f.write(struct.pack('=i', seed))
+
+        if initialization is not None:
+                f.write(initialization.tobytes()) 
+               
+    # run t-sne
+    subprocess.call(os.getcwd()+'/fast_tsne')
+            
+    # read data file
+    with open(os.getcwd()+'/temp/result.dat', 'rb') as f:
+        initError, = struct.unpack('=d', f.read(8))
+        n, = struct.unpack('=i', f.read(4))  
+        md, = struct.unpack('=i', f.read(4)) 
+        sz = struct.calcsize('=d')
+        buf = f.read()
+        x_tsne = [struct.unpack_from('=d', buf, sz*offset) for offset in range(n*md)]
+        x_tsne = np.array(x_tsne).reshape((n,md))
+
+    return x_tsne

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -980,7 +980,7 @@ int TSNE::computeGaussianPerplexity(double* X, int N, int D, unsigned int** _row
 			return -2;
 		}
 
-		size_t result; // need this to get rid of warning that otherwise appear
+		size_t result; // need this to get rid of warnings that otherwise appear
 		result = fread(val_P, sizeof(double), N * K, h);
 		fclose(h);
 
@@ -1498,7 +1498,7 @@ bool TSNE::load_data(const char *data_path, double** data, double** Y, int* n, i
 		return false;
 	}
 
-	size_t result; // need this to get rid of warning that otherwise appear
+	size_t result; // need this to get rid of warnings that otherwise appear
 
 	result = fread(n, sizeof(int), 1, h);     		// number of datapoints
 	result = fread(d, sizeof(int), 1, h);	  		// original dimensionality

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -1040,10 +1040,8 @@ int TSNE::computeGaussianPerplexity(double* X, int N, int D, unsigned int** _row
 
 		if (perplexity >0 ) {
 			printf("Calculating dynamic kernels using perplexity \n");
-			printf("K = %d and search_k = %d and nthreads = %d\n", K, search_k, nthreads);
 		}else {
 			printf("Using sigma = %lf\n", sigma);
-			printf("K = %d and search_k = %d and nthreads = %d\n", K, search_k, nthreads);
 		}
 		//Check if it returns enough neighbors
 		std::vector<int> closest;
@@ -1056,8 +1054,6 @@ int TSNE::computeGaussianPerplexity(double* X, int N, int D, unsigned int** _row
 				return -1;
 			}
 		}
-
-		printf("check done\n");
 
 		if (nthreads == 0) {
 			nthreads = std::thread::hardware_concurrency();

--- a/src/tsne.h
+++ b/src/tsne.h
@@ -46,15 +46,15 @@ public:
         int nbody_algo, int knn_algo, double early_exag_coeff,double * initialError, double* costs, bool no_momentum_during_exag,
 		int start_late_exag_iter, double late_exag_coeff, int n_trees,int search_k,int nterms, double intervals_per_integer, 
         int min_num_intervals, unsigned int nthreads);
-    bool load_data(const char *data_path, double** data, int* n, int* d, int* no_dims, double* theta,
+
+    bool load_data(const char *data_path, double** data, double** Y, int* n, int* d, int* no_dims, double* theta,
 		    double* perplexity, int* rand_seed, int* max_iter, int*
 		    stop_lying_iter, int* K, double * sigma, int* nbody_algo,
 		    int* compexag, double* early_exag_coeff,  int *
 		    no_momentum_during_exag, int * n_trees, int * search_k,
 		    int* start_late_exag_iter, double *late_exag_coeff,
-	       	    int * nterms, double * intervals_per_integer, int *min_num_intervals
-		    );
-    //bool load_initial_data(double** data);
+	       	    int * nterms, double * intervals_per_integer, int *min_num_intervals, bool *skip_random_init);
+
     void save_data(const char *result_path, double* data, int* landmarks, double* costs, int n, int d, double initialError);
     void symmetrizeMatrix(unsigned int** row_P, unsigned int** col_P, double** val_P, int N); // should be static!
 


### PR DESCRIPTION
I have implemented initialization. It works as follows: if there are N*no_dims doubles in the input file after the seed is read, then these are put into `Y`. Otherwise, no initialization is used. So all existing code  should keep working (full backwards compatibility).

As I am working in Python, I have also written a simple Python wrapper, which is very similar to your Matlab/R wrappers. I've seen that there is a third-party Python wrapper that I think uses Cython, but I guess it can be useful to have a very simple Python wrapper directly in here.

The Python wrapper supports initialization. I did *NOT* implement initialization support in the Matlab/R wrappers. Maybe it's better if you do it.