### PR TITLE
Added progress bar to K nearest neighbor search

### DIFF
--- a/src/progress_bar/LICENSE
+++ b/src/progress_bar/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2016 Prakhar Srivastav <prakhar@prakhar.me>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/progress_bar/ProgressBar.hpp
+++ b/src/progress_bar/ProgressBar.hpp
@@ -1,0 +1,52 @@
+#ifndef PROGRESSBAR_PROGRESSBAR_HPP
+#define PROGRESSBAR_PROGRESSBAR_HPP
+
+#include <chrono>
+#include <iostream>
+
+class ProgressBar {
+private:
+    unsigned int ticks = 0;
+
+    const unsigned int total_ticks;
+    const unsigned int bar_width;
+    const char complete_char = '=';
+    const char incomplete_char = ' ';
+    const std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+
+public:
+    ProgressBar(unsigned int total, unsigned int width, char complete, char incomplete) :
+            total_ticks {total}, bar_width {width}, complete_char {complete}, incomplete_char {incomplete} {}
+
+    ProgressBar(unsigned int total, unsigned int width) : total_ticks {total}, bar_width {width} {}
+
+    unsigned int operator++() { return ++ticks; }
+
+    void display() const
+    {
+        float progress = (float) ticks / total_ticks;
+        int pos = (int) (bar_width * progress);
+
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        auto time_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now-start_time).count();
+
+        std::cout << "[";
+
+        for (int i = 0; i < bar_width; ++i) {
+            if (i < pos) std::cout << complete_char;
+            else if (i == pos) std::cout << ">";
+            else std::cout << incomplete_char;
+        }
+        std::cout << "] " << int(progress * 100.0) << "% "
+                  << float(time_elapsed) / 1000.0 << "s\r";
+        std::cout.flush();
+    }
+
+    void done() const
+    {
+        display();
+        std::cout << std::endl;
+    }
+};
+
+#endif //PROGRESSBAR_PROGRESSBAR_HPP

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -1129,7 +1129,7 @@ int TSNE::computeGaussianPerplexity(double *X, int N, int D, unsigned int **_row
         }
     }
     printf("Done building tree. Beginning nearest neighbor search... \n");
-    ProgressBar bar(N,100);
+    ProgressBar bar(N,70);
     if (nthreads == 0) {
         nthreads = std::thread::hardware_concurrency();
     }
@@ -1218,7 +1218,7 @@ void TSNE::computeGaussianPerplexity(double *X, int N, int D, unsigned int **_ro
     printf("Done building tree. Beginning nearest neighbor search... \n");
 
 
-    ProgressBar bar(N,100);
+    ProgressBar bar(N,70);
 
 
     if (nthreads == 0) {


### PR DESCRIPTION
The K nearest neighbor search (via ANNOY or VP trees) is multithreaded, and used to asynchronously output the progress of each thread, making it difficult to determine how much longer it would take. This PR makes it into a single progress bar,  which is updated by all the threads (but only outputted by the first thread).