### PR TITLE
Multithread gradient descent and compute cost every 50 iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The only prerequisite is [FFTW](http://www.fftw.org/), which can be downloaded a
 ```bash
     g++ -std=c++11 -O3  src/sptree.cpp src/tsne.cpp src/nbodyfft.cpp  -o bin/fast_tsne -pthread -lfftw3 -lm
 ```
-And you're good to go! Check out `examples/` for usage.
+See [here](https://github.com/KlugerLab/FIt-SNE/issues/1) for solution to compilation errors relating to `clock_gettime`.
+
+Check out `examples/` for usage.
+
 
 ### Windows
 A Windows implementation has been added (thanks to [Josef Spidlen](https://github.com/jspidlen)!), and has been currently tested with MS Visual Studio 2015 (i.e., MS Visual Studio Version 14).

--- a/fast_tsne.R
+++ b/fast_tsne.R
@@ -129,7 +129,7 @@ fftRtsne <- function(X,
 	Y <- readBin(f, numeric(), n=n*d);
         Y <- t(matrix(Y, nrow=d));
         if (get_costs ) {
-            landmarks <- readBin(f, numeric(), n=max_iter,size=4);
+            landmarks <- readBin(f, numeric(), n=n,size=4);
             costs <- readBin(f, numeric(), n=max_iter,size=8);
             Yout <- list( Y=Y, costs=costs);
         }else {

--- a/fast_tsne.R
+++ b/fast_tsne.R
@@ -12,7 +12,8 @@ fftRtsne <- function(X,
 		     K=-1, sigma=-30, initialization=NULL,
 		     data_path=NULL, result_path=NULL,
 		     load_affinities=NULL,
-		     fast_tsne_path=NULL, nthreads=0, perplexity_list = NULL, ...) {
+		     fast_tsne_path=NULL, nthreads=0, perplexity_list = NULL, 
+                     get_costs = FALSE, ... ) {
 
 	if (is.null(fast_tsne_path)) {
 		if(.Platform$OS.type == "unix") {
@@ -126,11 +127,18 @@ fftRtsne <- function(X,
 	n <- readBin(f, integer(), n=1, size=4);
 	d <- readBin(f, integer(), n=1,size=4);
 	Y <- readBin(f, numeric(), n=n*d);
-	Yout <- t(matrix(Y, nrow=d));
-	close(f)
-	file.remove(data_path)
-	file.remove(result_path)
-	Yout
+        Y <- t(matrix(Y, nrow=d));
+        if (get_costs ) {
+            landmarks <- readBin(f, numeric(), n=max_iter,size=4);
+            costs <- readBin(f, numeric(), n=max_iter,size=8);
+            Yout <- list( Y=Y, costs=costs);
+        }else {
+            Yout <- Y;
+        }
+        close(f)
+        file.remove(data_path)
+        file.remove(result_path)
+        return(Yout)
 }
 
 

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -30,6 +30,8 @@
  *
  */
 
+#include <chrono>
+using namespace std::chrono;
 #include "winlibs/stdafx.h"
 
 #include <iostream>
@@ -131,7 +133,11 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
 
     // Set learning parameters
     float total_time = .0;
-    clock_t start, end;
+    struct timespec start, end;
+
+
+
+
     double momentum = .5, final_momentum = .8;
 
     // Step size
@@ -363,7 +369,7 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
 				   row_P[N - 2], row_P[N - 1], row_P[N]);
 		}
 	}
-	end = clock();
+        clock_gettime(CLOCK_MONOTONIC, &end);
 
     // Initialize solution (randomly)
     if (skip_random_init != true) {
@@ -408,7 +414,8 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
                (double) row_P[N] / ((double) N * (double) N));
     }
 
-    start = clock();
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    
     if (!exact) {
         if (nbody_algorithm == 2) {
             printf("Using FIt-SNE approximation.\n");
@@ -434,7 +441,7 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
                                            min_num_intervals);
                 } else {
                     computeFftGradient(P, row_P, col_P, val_P, Y, N, no_dims, dY, nterms, intervals_per_integer,
-                                       min_num_intervals);
+                                       min_num_intervals, nthreads);
                 }
             } else if (nbody_algorithm == 1) {
                 // Otherwise, compute the negative gradient using the Barnes-Hut approximation
@@ -445,7 +452,7 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
         if (measure_accuracy) {
             computeGradient(P, row_P, col_P, val_P, Y, N, no_dims, dY, theta);
             computeFftGradient(P, row_P, col_P, val_P, Y, N, no_dims, dY, nterms, intervals_per_integer,
-                               min_num_intervals);
+                               min_num_intervals, nthreads);
             computeExactGradientTest(Y, N, no_dims);
         }
 
@@ -488,7 +495,7 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
 
         // Print out progress
         if ((iter % 50 == 0 || iter == max_iter - 1)) {
-            clock_t end = clock();
+            clock_gettime(CLOCK_MONOTONIC, &end);
             double C = .0;
             if (exact) {
                 C = evaluateError(P, Y, N, no_dims);
@@ -501,10 +508,10 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
             }
             costs[iter] = C;
             if (iter > 0) {
-                total_time += (float) (end - start) / CLOCKS_PER_SEC;
-                printf("Iteration %d (50 iterations in %.2f seconds), cost %f\n", iter, (float) (end - start) / CLOCKS_PER_SEC, C);
+                total_time += (float) (end.tv_sec - start.tv_sec) / CLOCKS_PER_SEC;
+                printf("Iteration %d (50 iterations in %ld seconds), cost %f\n", iter, (end.tv_sec - start.tv_sec), C);
             }
-            start = clock();
+            clock_gettime(CLOCK_MONOTONIC, &start);
         }
     }
 
@@ -668,7 +675,13 @@ void TSNE::computeFftGradientOneD(double *P, unsigned int *inp_row_P, unsigned i
 // Compute the gradient of the t-SNE cost function using the FFT interpolation based approximation
 void TSNE::computeFftGradient(double *P, unsigned int *inp_row_P, unsigned int *inp_col_P, double *inp_val_P, double *Y,
                               int N, int D, double *dC, int n_interpolation_points, double intervals_per_integer,
-                              int min_num_intervals) {
+                              int min_num_intervals, unsigned int nthreads) {
+
+
+    if (nthreads == 0) {
+        nthreads = std::thread::hardware_concurrency();
+    }
+
     // Zero out the gradient
     for (int i = 0; i < N * D; i++) dC[i] = 0.0;
 
@@ -734,26 +747,58 @@ void TSNE::computeFftGradient(double *P, unsigned int *inp_row_P, unsigned int *
     sum_Q -= N;
 
     this->current_sum_Q = sum_Q;
+
+    double *pos_f = new double[N * 2];
+
     // Now, figure out the Gaussian component of the gradient. This corresponds to the "attraction" term of the
     // gradient. It was calculated using a fast KNN approach, so here we just use the results that were passed to this
     // function
     unsigned int ind2 = 0;
-    double *pos_f = new double[N * 2];
-    // Loop over all edges in the graph
-    for (unsigned int n = 0; n < N; n++) {
-        pos_f[n * 2 + 0] = 0;
-        pos_f[n * 2 + 1] = 0;
+    {
+        // Pre loop
+        std::vector<std::thread> threads(nthreads);
+        for (int t = 0; t < nthreads; t++) {
+            threads[t] = std::thread(std::bind(
+                    [&](const int bi, const int ei, const int t)
+                    {
+                        // loop over all items
+                        for(int n = bi;n<ei;n++)
+                        {
+                            // inner loop
+                            {
 
-        for (unsigned int i = inp_row_P[n]; i < inp_row_P[n + 1]; i++) {
-            // Compute pairwise distance and Q-value
-            ind2 = inp_col_P[i];
-            double d_ij = (xs[n] - xs[ind2]) * (xs[n] - xs[ind2]) + (ys[n] - ys[ind2]) * (ys[n] - ys[ind2]);
-            double q_ij = 1 / (1 + d_ij);
+                                double dim1 = 0;
+                                double dim2 = 0;
 
-            pos_f[n * 2 + 0] += inp_val_P[i] * q_ij * (xs[n] - xs[ind2]);
-            pos_f[n * 2 + 1] += inp_val_P[i] * q_ij * (ys[n] - ys[ind2]);
+                                for (unsigned int i = inp_row_P[n]; i < inp_row_P[n + 1]; i++) {
+                                // Compute pairwise distance and Q-value
+                                    unsigned int ind3 = inp_col_P[i];
+                                    double d_ij = (xs[n] - xs[ind3]) * (xs[n] - xs[ind3]) + (ys[n] - ys[ind3]) * (ys[n] - ys[ind3]);
+                                    double q_ij = 1 / (1 + d_ij);
+
+                                    dim1 += inp_val_P[i] * q_ij * (xs[n] - xs[ind3]);
+                                    dim2 += inp_val_P[i] * q_ij * (ys[n] - ys[ind3]);
+                                }
+                                pos_f[n * 2 + 0] = dim1;
+                                pos_f[n * 2 + 1] = dim2;
+
+                            }
+                        }
+
+                    },t*N/nthreads,(t+1)==nthreads?N:(t+1)*N/nthreads,t));
         }
-    }
+        std::for_each(threads.begin(),threads.end(),[](std::thread& x){x.join();});
+        // Post loop
+  }
+
+//clock_gettime(CLOCK_MONOTONIC, &finish2);
+//elapsed2 = (finish2.tv_nsec - start2.tv_nsec)/1E6;
+//cout << "MT" << elapsed2 <<endl;
+
+
+
+
+
 
     // Make the negative term, or F_rep in the equation 3 of the paper
     double *neg_f = new double[N * 2];

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -1665,7 +1665,7 @@ bool TSNE::load_data(const char *data_path, double **data, double **Y, int *n,
 
 
 // Function that saves map to a t-SNE file
-void TSNE::save_data(const char *result_path, double* data, int* landmarks, double* costs, int n, int d, double initialError) {
+void TSNE::save_data(const char *result_path, double* data, int* landmarks, double* costs, int n, int d, double initialError, int max_iter) {
 	// Open file, write first 2 integers and then the data
 	FILE *h;
 	if((h = fopen(result_path, "w+b")) == NULL) {
@@ -1677,7 +1677,7 @@ void TSNE::save_data(const char *result_path, double* data, int* landmarks, doub
 	fwrite(&d, sizeof(int), 1, h);
 	fwrite(data, sizeof(double), n * d, h);
 	fwrite(landmarks, sizeof(int), n, h);
-	fwrite(costs, sizeof(double), n, h);
+	fwrite(costs, sizeof(double), max_iter, h);
 	fclose(h);
 	printf("Wrote the %i x %i data matrix successfully.\n", n, d);
 }
@@ -1755,7 +1755,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		// Save the results
-		tsne->save_data(result_path, Y, landmarks, costs, N, no_dims, initialError);
+		tsne->save_data(result_path, Y, landmarks, costs, N, no_dims, initialError, max_iter);
 
 		// Clean up the memory
 		free(data); data = NULL;

--- a/src/tsne.h
+++ b/src/tsne.h
@@ -61,6 +61,7 @@ public:
     void symmetrizeMatrix(unsigned int **row_P, unsigned int **col_P, double **val_P, int N); // should be static!
 
 private:
+    double current_sum_Q;
     void computeGradient(double *P, unsigned int *inp_row_P, unsigned int *inp_col_P, double *inp_val_P, double *Y,
                          int N, int D, double *dC, double theta);
 
@@ -81,6 +82,7 @@ private:
     double evaluateError(unsigned int *row_P, unsigned int *col_P, double *val_P, double *Y, int N, int D,
                          double theta);
 
+    double evaluateErrorFft(unsigned int *row_P, unsigned int *col_P, double *val_P, double *Y, int N, int D);
     void zeroMean(double *X, int N, int D);
 
 	double distances2similarities(double *D, double *P, int N, int n, double perplexity, double sigma, bool ifSquared);

--- a/src/tsne.h
+++ b/src/tsne.h
@@ -71,7 +71,7 @@ private:
 
     void computeFftGradientOneD(double *P, unsigned int *inp_row_P, unsigned int *inp_col_P, double *inp_val_P,
                                     double *Y, int N, int D, double *dC, int n_interpolation_points,
-                                    double intervals_per_integer, int min_num_intervals);
+                                    double intervals_per_integer, int min_num_intervals, unsigned int nthreads);
 
     void computeExactGradient(double *P, double *Y, int N, int D, double *dC);
 

--- a/src/tsne.h
+++ b/src/tsne.h
@@ -67,7 +67,7 @@ private:
 
     void computeFftGradient(double *P, unsigned int *inp_row_P, unsigned int *inp_col_P, double *inp_val_P, double *Y,
                                 int N, int D, double *dC, int n_interpolation_points, double intervals_per_integer,
-                                int min_num_intervals);
+                                int min_num_intervals, unsigned int nthreads);
 
     void computeFftGradientOneD(double *P, unsigned int *inp_row_P, unsigned int *inp_col_P, double *inp_val_P,
                                     double *Y, int N, int D, double *dC, int n_interpolation_points,

--- a/src/tsne.h
+++ b/src/tsne.h
@@ -56,7 +56,7 @@ public:
 
     //bool load_initial_data(double** data);
     void save_data(const char *result_path, double *data, int *landmarks, double *costs, int n, int d,
-                   double initialError);
+                   double initialError, int max_iter);
 
     void symmetrizeMatrix(unsigned int **row_P, unsigned int **col_P, double **val_P, int N); // should be static!
 


### PR DESCRIPTION
Two improvements:

1. The computation of the attractive term at each iteration now is now multithreaded, which gives approximately 3x speed-up for datasets of ~1 million points on multithreaded machines. 
2. The approximate KL divergence is computed every 50 iterations and output to the console. R wrapper has been updated to read this in.