### PR TITLE
Refactored default nthreads setting

### DIFF
--- a/src/time_code.h
+++ b/src/time_code.h
@@ -9,7 +9,7 @@
                                                                
 #define END_TIME(LABEL) {          			\
                 std::chrono::steady_clock::time_point ENDVAR = std::chrono::steady_clock::now();      \
-                printf("%s: %lld ms\n",LABEL, std::chrono::duration_cast<std::chrono::milliseconds>(ENDVAR-STARTVAR).count());       \
+                printf("%s: %ld ms\n",LABEL, std::chrono::duration_cast<std::chrono::milliseconds>(ENDVAR-STARTVAR).count());       \
 }                                                                       
 #else 
 #define INITIALIZE_TIME                      

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -497,6 +497,8 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
 
         // Print out progress
         if (iter > 0 && (iter % 50 == 0 || iter == max_iter - 1)) {
+	INITIALIZE_TIME;
+        START_TIME;
             double C = .0;
             if (exact) {
                 C = evaluateError(P, Y, N, no_dims);
@@ -523,6 +525,7 @@ int TSNE::run(double *X, int N, int D, double *Y, int no_dims, double perplexity
             total_time += std::chrono::duration_cast<std::chrono::milliseconds>(now-start_time).count();
             printf("Iteration %d (50 iterations in %.2f seconds), cost %f\n", iter, std::chrono::duration_cast<std::chrono::milliseconds>(now-start_time).count()/(float)1000.0, C);
             start_time = std::chrono::steady_clock::now();
+    END_TIME("Computing Error");
         }
     }
 

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -664,14 +664,14 @@ void TSNE::computeFftGradientOneD(double *P, unsigned int *inp_row_P, unsigned i
 
         PARALLEL_FOR(nthreads, N, {
             double dim1 = 0;
-            for (unsigned int i = inp_row_P[n]; i < inp_row_P[n + 1]; i++) {
+            for (unsigned int i = inp_row_P[loop_i]; i < inp_row_P[loop_i + 1]; i++) {
                 // Compute pairwise distance and Q-value
                 unsigned int ind3 = inp_col_P[i];
-                double d_ij = Y[n] - Y[ind3];
+                double d_ij = Y[loop_i] - Y[ind3];
                 double q_ij = 1 / (1 + d_ij * d_ij);
                 dim1 += inp_val_P[i] * q_ij * d_ij;
             }
-                pos_f[n] = dim1;
+                pos_f[loop_i] = dim1;
 
         });
 


### PR DESCRIPTION
Partially addressed #37 by refactoring the default setting of nthreads into `run().` Before this commit, the appropriate setting of nthreads was not being passed to `computeError()`, so it was not actually being multithreaded. 