### PR TITLE
Some convenient defaults in the python wrapper

### DIFF
--- a/examples/test.ipynb
+++ b/examples/test.ipynb
@@ -31,9 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -76,9 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -883,9 +879,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1683,7 +1677,7 @@
     "\n",
     "# PCA initialization is not important for MNIST, but can be handy for other datasets\n",
     "\n",
-    "Z = fast_tsne(X50, perplexity=50, stop_lying_iter=500, initialization=PCAinit)\n",
+    "Z = fast_tsne(X50, perplexity=50, stop_early_exag_iter=500, initialization=PCAinit)\n",
     "\n",
     "plt.figure(figsize=(5,5))\n",
     "plt.scatter(Z[:,0], Z[:,1], c=col[y], s=1)\n",
@@ -1722,9 +1716,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2518,10 +2510,10 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:])\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
     "Z2 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], map_dims=1)\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:], map_dims=1)\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
     "plt.subplot(121)\n",
@@ -2544,9 +2536,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3340,10 +3330,10 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:])\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
     "Z2 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:], \n",
     "               knn_algo='vp-tree')\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
@@ -3366,9 +3356,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4162,10 +4150,10 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:])\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
     "Z2 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:], \n",
     "               nbody_algo='Barnes-Hut')\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
@@ -4188,9 +4176,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4984,10 +4970,10 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:])\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
     "Z2 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], theta=0)\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:], theta=0)\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
     "plt.subplot(121)\n",
@@ -5009,9 +4995,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -5804,9 +5788,9 @@
     }
    ],
    "source": [
-    "Z1 = fast_tsne(X50, perplexity=50, stop_lying_iter=500, initialization=PCAinit)\n",
+    "Z1 = fast_tsne(X50, perplexity=50, stop_early_exag_iter=500, initialization=PCAinit)\n",
     "\n",
-    "Z2 = fast_tsne(X50, perplexity=50, stop_lying_iter=500, initialization=PCAinit, \n",
+    "Z2 = fast_tsne(X50, perplexity=50, stop_early_exag_iter=500, initialization=PCAinit, \n",
     "               late_exag_coeff=4, start_late_exag_iter=500)\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
@@ -5829,9 +5813,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -7414,11 +7396,11 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:], \n",
     "               load_affinities = 'save')\n",
     "\n",
     "Z2 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:], \n",
     "               load_affinities = 'load')\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
@@ -7433,11 +7415,11 @@
     "# And now for the exact t-SNE\n",
     "\n",
     "Z1 = fast_tsne(X50[ind1k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind1k,:], theta=0, \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind1k,:], theta=0, \n",
     "               load_affinities = 'save')\n",
     "\n",
     "Z2 = fast_tsne(X50[ind1k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind1k,:], theta=0, \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind1k,:], theta=0, \n",
     "               load_affinities = 'load')\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
@@ -7460,9 +7442,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -8256,10 +8236,10 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:])\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
-    "Z2 = fast_tsne(X50[ind5k,:], perplexity=-1, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:], sigma = 10, K=10)\n",
+    "Z2 = fast_tsne(X50[ind5k,:], sigma=10, K=10, max_iter=500, early_exag_coeff=4, \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
     "plt.subplot(121)\n",
@@ -8281,9 +8261,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -9077,11 +9055,10 @@
    ],
    "source": [
     "Z1 = fast_tsne(X50[ind5k,:], perplexity=50, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:])\n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
-    "Z2 = fast_tsne(X50[ind5k,:], perplexity=0, max_iter=500, early_exag_coeff=4, \n",
-    "               stop_lying_iter=100, initialization=PCAinit[ind5k,:],\n",
-    "               perplexity_list=[10,50,100])\n",
+    "Z2 = fast_tsne(X50[ind5k,:], perplexity_list=[10,50,100], max_iter=500, early_exag_coeff=4, \n",
+    "               stop_early_exag_iter=100, initialization=PCAinit[ind5k,:])\n",
     "\n",
     "plt.figure(figsize=(8,4))\n",
     "plt.subplot(121)\n",
@@ -9110,7 +9087,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/fast_tsne.py
+++ b/fast_tsne.py
@@ -15,7 +15,7 @@ import struct
 import numpy as np
 
 def fast_tsne(X, theta=.5, perplexity=30, map_dims=2, max_iter=1000, 
-              stop_lying_iter=250, K=-1, sigma=-30, nbody_algo='FFT', knn_algo='annoy',
+              stop_lying_iter=250, K=-1, sigma=-1, nbody_algo='FFT', knn_algo='annoy',
               mom_switch_iter=250, momentum=.5, final_momentum=.8, learning_rate=200,
               early_exag_coeff=12, no_momentum_during_exag=0, n_trees=50, 
               search_k=None, start_late_exag_iter=-1, late_exag_coeff=-1,
@@ -50,6 +50,12 @@ def fast_tsne(X, theta=.5, perplexity=30, map_dims=2, max_iter=1000,
         load_affinities = 2
     else:
         load_affinities = 0
+
+    if perplexity_list is not None:
+        perplexity = 0
+
+	if sigma > 0 and K > 0:
+		perplexity = -1
     
     # write data file
     with open(os.getcwd() + '/data.dat', 'wb') as f:


### PR DESCRIPTION
Very minor PR: usability improvements in the Python wrapper.

Also, I renamed `stop_lying_iter` parameter to `stop_early_exag_iter` (only in Python) because I noticed that "lying" confuses people, and also `start_early_exag_iter` is not called "start lying", so it makes sense to unify this.