### PR TITLE
When using fixed sigma, it should be std of Gaussian kernel

### DIFF
--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -1091,7 +1091,7 @@ double TSNE::distances2similarities(double *D, double *P, int N, int n, double p
         }
     }else{
         // Using fixed kernel width: no iterations needed
-        beta = 1/sigma;
+        beta = 1/(2*sigma*sigma);
         for(int m = 0; m < N; m++) P[m] = exp(-beta * (ifSquared ? D[m] : D[m]*D[m]));
         if (n >= 0) P[n] = DBL_MIN;
 


### PR DESCRIPTION
When using fixed sigma parameter, it makes sense that it actually corresponds to the standard deviation of the Gaussian kernel (as written in the 2008 t-SNE paper), meaning that we should have exp(-distance^2 / (2*sigma^2)).