### PR TITLE
Added <functional> to parallel_for

### DIFF
--- a/src/parallel_for.h
+++ b/src/parallel_for.h
@@ -1,6 +1,7 @@
 #ifndef PARALLEL_FOR_H
 #define PARALLEL_FOR_H
 #include<algorithm>
+#include <functional>
 #include <thread>
 #include <vector>
 #if defined(_OPENMP)


### PR DESCRIPTION
Fixed problem where one some compilers <functional> was not included from the other headers, addressing first part of #50.