### PR TITLE
Fixing compile errors on Windows

### DIFF
--- a/fast_tsne.R
+++ b/fast_tsne.R
@@ -96,7 +96,7 @@ fftRtsne <- function(X,
 		     fast_tsne_path = NULL, nthreads = 0, perplexity_list = NULL, 
          get_costs = FALSE, df = 1.0) {
   
-  version_number <- '1.2.0'
+  version_number <- '1.2.1'
 
 	if (is.null(fast_tsne_path)) {
 		if (.Platform$OS.type == "unix") {

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -121,7 +121,7 @@ function [mappedX, costs, initialError] = fast_tsne(X, opts)
 % IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
 % OF SUCH DAMAGE.
 
-    version_number = '1.2.0';
+    version_number = '1.2.1';
 
     % default parameters and flags 
     p.perplexity = 30;

--- a/fast_tsne.py
+++ b/fast_tsne.py
@@ -169,7 +169,7 @@ def fast_tsne(
         is True.
     """
 
-    version_number = "1.2.0"
+    version_number = "1.2.1"
 
     # X should be a numpy array of 64-bit doubles
     X = np.array(X).astype(float)

--- a/src/tsne.cpp
+++ b/src/tsne.cpp
@@ -2038,7 +2038,7 @@ void TSNE::save_data(const char *result_path, double* data, double* costs, int n
 
 
 int main(int argc, char *argv[]) {
-        const char version_number[] =  "1.2.0";
+        const char version_number[] =  "1.2.1";
 	printf("=============== t-SNE v%s ===============\n", version_number);
 
 	// Define some variables

--- a/src/winlibs/mman.c
+++ b/src/winlibs/mman.c
@@ -178,3 +178,28 @@ int munlock(const void *addr, size_t len)
     
     return -1;
 }
+#if !defined(__MINGW32__)
+int ftruncate(int fd, unsigned int size) {
+	if (fd < 0) {
+		errno = EBADF;
+		return -1;
+	}
+
+	HANDLE h = (HANDLE)_get_osfhandle(fd);
+	unsigned int cur = SetFilePointer(h, 0, NULL, FILE_CURRENT);
+	if (cur == ~0 || SetFilePointer(h, size, NULL, FILE_BEGIN) == ~0 || !SetEndOfFile(h)) {
+		int error = GetLastError();
+		switch (GetLastError()) {
+		case ERROR_INVALID_HANDLE:
+			errno = EBADF;
+			break;
+		default:
+			errno = EIO;
+			break;
+		}
+		return -1;
+	}
+
+	return 0;
+}
+#endif

--- a/src/winlibs/mman.h
+++ b/src/winlibs/mman.h
@@ -68,9 +68,15 @@ MMANSHARED_EXPORT int     _mprotect(void *addr, size_t len, int prot);
 MMANSHARED_EXPORT int     msync(void *addr, size_t len, int flags);
 MMANSHARED_EXPORT int     mlock(const void *addr, size_t len);
 MMANSHARED_EXPORT int     munlock(const void *addr, size_t len);
-
+#if !defined(__MINGW32__)
+MMANSHARED_EXPORT int ftruncate(int fd, unsigned int size);
+#endif
 #ifdef __cplusplus
 }
 #endif
+
+
+
+
 
 #endif /*  _SYS_MMAN_H_ */


### PR DESCRIPTION
When FIt-SNE was adapted to Windows, @JosefFlowJo made some crucial changes to the Annoy code that is used for nearest neighbor calculation. When we updated Annoy in 42e4617, we did not carry forward those changes, breaking FIt-SNE on Windows. This pull request re-implements those changes on the newer version of the Annoy code that was previously incorporated into FIt-SNE. 

This PR addresses #95.