### PR TITLE
Fix sourcing of rsvd/irlba to return more meaningful error

### DIFF
--- a/fast_tsne.R
+++ b/fast_tsne.R
@@ -155,12 +155,14 @@ fftRtsne <- function(X,
             if (rand_seed != -1)  {
                 set.seed(rand_seed)
             }
-            if (requireNamespace("rsvd")) {
+            if (tryCatch(requireNamespace("rsvd"),
+                         error = function(e){FALSE})) {
                 message('Using rsvd() to compute the top PCs for initialization.')
                 X_c <- scale(X, center=T, scale=F)
                 rsvd_out <- rsvd(X_c, k=dims)
                 X_top_pcs <- rsvd_out$u %*% diag(rsvd_out$d, nrow=dims)
-            }else if(requireNamespace("irlba")) { 
+            }else if(tryCatch(requireNamespace("irlba"),
+                              error = function(e){FALSE})) { 
                 message('Using irlba() to compute the top PCs for initialization.')
                 X_colmeans <- colMeans(X)
                 irlba_out <- irlba(X,nv=dims, center=X_colmeans)


### PR DESCRIPTION
@linqiaozhi, in this PR I have just strengthened the sourcing of rsvd/irlba packages for PCA initialisation. Now, if an error occurs with `requireNmaespace("rsvd")` it returns `FALSE` and proceed to checking if `irlba` has been installed. If neither of these packages have been installed it diverts to much more informative error message.